### PR TITLE
Make gitlab the default 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "sinatra"
-gem "octokit"
+gem "gitlab"
 gem "thin"
 gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,39 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
     daemons (1.2.6)
     dotenv (2.2.2)
     eventmachine (1.2.5)
-    faraday (0.14.0)
-      multipart-post (>= 1.2, < 3)
-    multipart-post (2.0.0)
+    gitlab (4.3.0)
+      httparty
+      terminal-table
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
+    multi_xml (0.6.0)
     mustermann (1.0.2)
-    octokit (4.8.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
-    public_suffix (3.0.2)
     rack (2.0.4)
     rack-protection (2.0.1)
       rack
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
     sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
       rack-protection (= 2.0.1)
       tilt (~> 2.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     tilt (2.0.8)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   dotenv
-  octokit
+  gitlab
   sinatra
   thin
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ the repo OR a github access token.
 ## Setup
 
 1. Run this Sinatra app with the following env vars
-  * GITHUB_TOKEN: an access token for a user with `repo` access scope. OR
-  * GITHUB_USER and GITHUB_PASSWORD: the username and password of a github user.
+  * GITLAB_TOKEN: an access token for a user with `repo` access scope.
+  * GITLAB_ENDPOINT: the URL for Gitlab's API
   * PR_LABEL: the label's text string to trigger the bot.
   * REVIEWER_POOL: a list of github username lists.
 1. Add a webhook to your github repository


### PR DESCRIPTION
There a `github` branch that keeps the old behaviour of integrating with a Github repo.

Master now integrates with Gitlab