### PR TITLE
Expand strategies: each team can have their own, new "Approval" strategy

### DIFF
--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -58,10 +58,8 @@ spec:
         env:
         - name: GITLAB_ENDPOINT
           value: '__GITLAB_ENDPOINT__'
-        - name: STRATEGY
-          value: '__STRATEGY__'
         - name: REVIEWER_POOL
-          value: '[{"count":1,"members":["david", "guillaume", "cedricpim", "dmytro.soltys", "marion", "nikita.avvakoumov"]},{"count":1,"members":["toon.willems", "greg"]},{"count":1,"members":["jeroen", "vincent", "steven"],"allow_out_of_team_reviews": false},{"count":1,"members":["andruby", "raphael", "aleksander", "nb", "johan"]},{"count":1,"members":["radan", "predrag.radenkovic", "fabien"]},{"count":1,"members":["miha", "nikola", "agon"]}]'
+          value: '[{"strategy":"teams","count":1,"members":["david", "guillaume", "cedricpim", "dmytro.soltys", "marion", "nikita.avvakoumov"]},{"strategy":"teams","count":1,"members":["toon.willems", "greg"]},{"strategy":"teams","count":1,"members":["jeroen", "vincent", "steven"],"allow_out_of_team_reviews": false},{"strategy":"teams","count":1,"members":["andruby", "raphael", "aleksander", "nb", "johan"]},{"strategy":"teams","count":1,"members":["radan", "predrag.radenkovic", "fabien"]},{"strategy":"teams","count":1,"members":["miha", "nikola", "agon"]}]'
         - name: PR_LABEL
           value: '__PR_LABEL__'
         - name: GITLAB_TOKEN

--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -59,7 +59,7 @@ spec:
         - name: GITLAB_ENDPOINT
           value: '__GITLAB_ENDPOINT__'
         - name: REVIEWER_POOL
-          value: '[{"strategy":"teams","count":1,"members":["david", "guillaume", "cedricpim", "dmytro.soltys", "marion", "nikita.avvakoumov"]},{"strategy":"teams","count":1,"members":["toon.willems", "greg"]},{"strategy":"teams","count":1,"members":["jeroen", "vincent", "steven"],"allow_out_of_team_reviews": false},{"strategy":"teams","count":1,"members":["andruby", "raphael", "aleksander", "nb", "johan"]},{"strategy":"teams","count":1,"members":["radan", "predrag.radenkovic", "fabien"]},{"strategy":"teams","count":1,"members":["miha", "nikola", "agon"]}]'
+          value: '[{"strategy":"teams","count":1,"members":["david", "guillaume", "cedricpim", "dmytro.soltys", "marion", "nikita.avvakoumov"]},{"strategy":"teams","count":1,"members":["toon.willems", "ana.castro", "richard"]},{"strategy":"teams","count":1,"members":["jeroen", "vincent", "steven"],"allow_out_of_team_reviews": false},{"strategy":"teams","count":1,"members":["andruby", "raphael", "aleksander", "nb", "johan"]},{"strategy":"whole_team","count":1,"members":["radan", "predrag.radenkovic", "fabien", "manuel.costareis"],"team_handle":"reporting-team"},{"strategy":"teams","count":1,"members":["miha", "nikola", "agon", "nikita.misharin"]}]'
         - name: PR_LABEL
           value: '__PR_LABEL__'
         - name: GITLAB_TOKEN

--- a/lib/strategies/base.rb
+++ b/lib/strategies/base.rb
@@ -1,5 +1,21 @@
 class BaseStrategy
-  def initialize(reviewer_pool: )
+  def initialize(reviewer_pool:, pull_request: )
     @reviewer_pool = reviewer_pool
+    @pull_request = pull_request
+  end
+
+  def assign!
+    @pull_request.set_assigner!(reviewer)
+    @pull_request.add_comment!(message)
+  end
+
+  private
+
+  def message
+    "Thank you @#{@pull_request.creator} for your contribution! I have determined that @#{reviewer} shall review your code"
+  end
+
+  def reviewer
+    @reviewer ||= pick_reviewers(pr_creator: @pull_request.creator).first
   end
 end

--- a/lib/strategies/whole_team_strategy.rb
+++ b/lib/strategies/whole_team_strategy.rb
@@ -1,0 +1,34 @@
+require_relative 'base'
+
+# Split your app into teams, this strategy figures out which team
+# the creator is from and:
+# - assigns the creator of the MR as assignee
+# - adds an approval rule with the creator's team as approvers
+#   (gotten from @reviewer_pool's team_handle)
+# - removes the default approval rule (everybody can approve)
+# - write a comment to alert the reviewers
+class WholeTeamStrategy < BaseStrategy
+  def pick_reviewers(pr_creator: )
+    [pr_creator]
+  end
+
+  def assign!
+    @pull_request.set_assigner!(reviewer)
+
+    @pull_request.set_approval_rule!(approvers)
+    @pull_request.remove_default_approval_rule!
+
+    @pull_request.add_comment!(message)
+  end
+
+  private
+
+  def approvers
+    creator_team = @reviewer_pool.detect { |team| Array(team["members"]).include?(@pull_request.creator) }
+    Array(creator_team&.fetch("team_handle", nil))
+  end
+
+  def message
+    "Thank you @#{@pull_request.creator} for your contribution! #{approvers.map { |approver| "@#{approver}" }.join(", ")} it's now your turn to review."
+  end
+end


### PR DESCRIPTION
## Description

This change allows for each team to define their review strategy. It moves the strategy from an env var to the reviewer_pool env var. The default is changed to `teams` as this is what we have been using so far.

⚠️ it's now impossible to go back to `list` strategy (will break on trying to find strategy). default is `teams` so that if someone not in a team creates a MR (like Tim), it still gets assigned to someone as described in `TeamsStrategy`

New added strategy: `WholeTeamStrategy`, which allows for the whole team to review the MR. 

Required in the `ENV['REVIEWER_POOL']` payload of the team:
- a `'strategy':'whole_team'` key/val
- a `'team_handle':'gitlab-handle-of-the-team'` key/val (example: `'team_handle':'reporting-team'`)
    
It will:
- set the MR creator as the assignee
- set a new approval rule with the team handle => whole team can approve
- remove default rule (everybody can approve)
- write a comment to alert the team => in the past gitlab was sending emails on approval rules change, but not anymore, so this is a way to get alerted.